### PR TITLE
filter-sarif changes

### DIFF
--- a/codeql/action.yml
+++ b/codeql/action.yml
@@ -73,6 +73,7 @@ runs:
         upload: failure-only  
 
     - name: Set SARIF file
+      shell: bash
       run: |
         sarif_file="${{ inputs.language }}.sarif"
         if [[ "${{ inputs.language }}" == "javascript-typescript" ]]; then
@@ -85,10 +86,6 @@ runs:
             sarif_file="ruby.sarif"  
           elif [[ "${{ inputs.language }}" == "swift" ]]; then
             sarif_file="swift.sarif"  
-          elif [[ "${{ inputs.language }}" == "go" ]]; then
-            sarif_file="go.sarif"  
-          elif [[ "${{ inputs.language }}" == "java" ]]; then
-            sarif_file="java.sarif"              
           else
             sarif_file="${{ inputs.language }}.sarif"        
           fi
@@ -97,16 +94,16 @@ runs:
 
     - name: Filter SARIF
       uses: advanced-security/filter-sarif@v1
-        with:
-          patterns: |
-            -**/*:*/hardcoded-credentials
-            -**/*:*/disabling-certificate-validation
-            -**/*:*/missing-rate-limiting
-            -**/*:py/request-without-cert-validation
-          input: sarif-results/${{ env.SARIF_FILE }}
-          output: sarif-results/${{ env.SARIF_FILE }}
+      with:
+        patterns: |
+          - **/*:*/hardcoded-credentials
+          - **/*:*/disabling-certificate-validation
+          - **/*:*/missing-rate-limiting
+          - **/*:py/request-without-cert-validation
+        input: sarif-results/${{ env.SARIF_FILE }}
+        output: sarif-results/${{ env.SARIF_FILE }}
 
     - name: Upload SARIF
       uses: github/codeql-action/upload-sarif@v3
       with:
-        sarif_file: sarif-results/${{ env.SARIF_FILE }}           
+        sarif_file: sarif-results/${{ env.SARIF_FILE }}     

--- a/codeql/action.yml
+++ b/codeql/action.yml
@@ -69,3 +69,44 @@ runs:
       uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{ inputs.language }}"
+        output: sarif-results
+        upload: failure-only  
+
+    - name: Set SARIF file
+      run: |
+        sarif_file="${{ inputs.language }}.sarif"
+        if [[ "${{ inputs.language }}" == "javascript-typescript" ]]; then
+            sarif_file="javascript.sarif"
+          elif [[ "${{ inputs.language }}" == "python" ]]; then
+            sarif_file="python.sarif"  
+          elif [[ "${{ inputs.language }}" == "java-kotlin" ]]; then
+            sarif_file="kotlin.sarif"  
+          elif [[ "${{ inputs.language }}" == "ruby" ]]; then
+            sarif_file="ruby.sarif"  
+          elif [[ "${{ inputs.language }}" == "swift" ]]; then
+            sarif_file="swift.sarif"  
+          elif [[ "${{ inputs.language }}" == "go" ]]; then
+            sarif_file="go.sarif"  
+          elif [[ "${{ inputs.language }}" == "java" ]]; then
+            sarif_file="java.sarif"              
+          else
+            sarif_file="${{ inputs.language }}.sarif"        
+          fi
+
+        echo "SARIF_FILE=${sarif_file}" >> $GITHUB_ENV    
+
+    - name: Filter SARIF
+      uses: advanced-security/filter-sarif@v1
+        with:
+          patterns: |
+            -**/*:*/hardcoded-credentials
+            -**/*:*/disabling-certificate-validation
+            -**/*:*/missing-rate-limiting
+            -**/*:py/request-without-cert-validation
+          input: sarif-results/${{ env.SARIF_FILE }}
+          output: sarif-results/${{ env.SARIF_FILE }}
+
+    - name: Upload SARIF
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: sarif-results/${{ env.SARIF_FILE }}           

--- a/codeql/action.yml
+++ b/codeql/action.yml
@@ -86,6 +86,10 @@ runs:
             sarif_file="ruby.sarif"  
           elif [[ "${{ inputs.language }}" == "swift" ]]; then
             sarif_file="swift.sarif"  
+          elif [[ "${{ inputs.language }}" == "go" ]]; then
+            sarif_file="go.sarif"  
+          elif [[ "${{ inputs.language }}" == "java" ]]; then
+            sarif_file="java.sarif"              
           else
             sarif_file="${{ inputs.language }}.sarif"        
           fi


### PR DESCRIPTION
Remove Hard-coded credentials rule
Justification: too many false positives
Remove certificate validation rule
Justification: We have other methods to enforce this within the site environment. Including mTLS and EdgeTLS enforcement
Remove: Missing rate limiting
Justification - We do not enforce rate limiting in the apps. This is abstracted.